### PR TITLE
fixed title for communities list of connection

### DIFF
--- a/client/frontend/src/main-platform/your-communities/components/YourCommunitiesBody.tsx
+++ b/client/frontend/src/main-platform/your-communities/components/YourCommunitiesBody.tsx
@@ -113,7 +113,7 @@ function YourCommunitiesBody(props: Props) {
       props.refreshToken
     );
     if (data.success === 1) {
-      setUsername(`${data.content.user?.firstName} ${data.content.user?.lastName}`);
+      setUsername(`${data.content.user?.firstName}`);
     }
   }
 


### PR DESCRIPTION
**Update**
1. Changed tittle for viewing connection's communities from full name to first name

**Testing**
1. Verify user X's connections is titled with just first name