### PR TITLE
Unfollow Community Front-end Action

### DIFF
--- a/client/frontend/src/main-platform/community/components/FollowButton.tsx
+++ b/client/frontend/src/main-platform/community/components/FollowButton.tsx
@@ -132,7 +132,7 @@ function FollowButton(props: Props) {
         setSnackbarMode('notify');
       } else {
         setTransition(() => slideLeft);
-        setSnackbarMessage('There was an error performing this action.');
+        setSnackbarMessage(`There was an error requesting to follow ${props.name}.`);
         setSnackbarMode('error');
       }
     } else setFollowMenuAnchorEl(null);
@@ -167,7 +167,7 @@ function FollowButton(props: Props) {
         setSnackbarMode('notify');
       } else {
         setTransition(() => slideLeft);
-        setSnackbarMessage('There was an error performing this action.');
+        setSnackbarMessage('There was an error cancelling your follow request.');
         setSnackbarMode('error');
       }
     } else setFollowMenuAnchorEl(null);
@@ -198,7 +198,7 @@ function FollowButton(props: Props) {
         setSnackbarMode('notify');
       } else {
         setTransition(() => slideLeft);
-        setSnackbarMessage('There was an error performing this action.');
+        setSnackbarMessage(`There was an error trying to unfollow ${props.name}.`);
         setSnackbarMode('error');
       }
     } else setFollowMenuAnchorEl(null);


### PR DESCRIPTION
**Updates**
Handle functionality for unfollowing community on the frontend

**Testing**
- Go to a community that you are following. Click follow-as, then click a community that you are following as, then confirm the unfollow. The frontend status should reflect the open state, and should remain that way after reloading