### PR TITLE
Added redux access to makeRequest

### DIFF
--- a/client/frontend/src/helpers/functions/makeRequest.ts
+++ b/client/frontend/src/helpers/functions/makeRequest.ts
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import { getStore } from '../../redux/store/persistedStore';
 
 type Config = {
   headers: {
@@ -6,19 +7,23 @@ type Config = {
   };
 };
 
+const store = getStore();
+
 export function makeRequest(
   method: 'GET' | 'POST',
   url: string,
   data: { [key: string]: any } = {},
-  authenticated = false,
-  accessToken = '',
-  refreshToken = ''
+  ...rest: any
 ) {
+  const state = store.getState();
+  const { accessToken, refreshToken } = state;
+
   const config: Config = {
     headers: {
       Authorization: `Bearer ${accessToken}`,
     },
   };
-  if (method === 'GET') return axios.get(url, authenticated ? config : {});
-  return axios.post(url, data, authenticated ? config : {});
+
+  if (method === 'GET') return axios.get(url, ( accessToken && refreshToken ) ? config : {});
+  return axios.post(url, data, ( accessToken && refreshToken ) ? config : {});
 }

--- a/client/frontend/src/redux/store/persistedStore.tsx
+++ b/client/frontend/src/redux/store/persistedStore.tsx
@@ -25,3 +25,7 @@ export const PersistedStore = createStore(
 PersistedStore.subscribe(() => {
   saveState(PersistedStore.getState());
 });
+
+export function getStore() {
+  return PersistedStore;
+}


### PR DESCRIPTION
Updates makeRequest so that we no longer need to pass accessToken and refreshToken into the function. The function now is able to access the redux store directly.

**New Usage**
` const { data } = await makeRequest('GET', '/api/some/route') 
  const { data } = await makeRequest('POST', '/api/some/post/route', { data: some })
`

**Note**
I added ...rest to the function so that existing makeRequest calls do not break. We can refactor as we work on various files. With beta test coming soon, I don't want to update every single file in the project in 1 PR